### PR TITLE
Enable people to specify their own documentation/required files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [x] check the box for **Pull Request** events
 2. Add a `.github/config.yml` file that contains the contents you would like to reply within an `updateDocsComment`
 3. Optionally, you can also add a `whiteList` that includes terms, that if found in the title, the bot will not comment on.
+4. Optionally, you can also add `targetFiles` that includes the files or paths to consider documentation.
 ```yml
 # Configuration for update-docs - https://github.com/behaviorbot/update-docs
 
@@ -21,6 +22,10 @@ updateDocsComment: >
 updateDocsWhiteList:
   - bug
   - chore
+
+updateDocsTargetFiles:
+  - README
+  - docs/
 ```
 
 ## Setup

--- a/index.js
+++ b/index.js
@@ -1,16 +1,27 @@
 module.exports = robot => {
   robot.on('pull_request.opened', async context => {
     const files = await context.github.pullRequests.getFiles(context.issue())
+    const config = await context.config('config.yml')
     const docs = files.data.find(function (file) {
-      if (file.filename.startsWith('README') || file.filename.includes('docs/')) {
-        return file
+      let targetFile
+
+      if (config.updateDocsTargetFiles) {
+        targetFile = config.updateDocsTargetFiles.find(function (item) {
+          if (file.filename.startsWith(item) || file.filename.includes(item)) {
+            return item
+          }
+        })
+        return targetFile
+      } else {
+        if (file.filename.startsWith('README') || file.filename.includes('docs/')) {
+          return file
+        }
       }
     })
 
     if (!docs) {
       // Get config.yml and comment that on the PR
       try {
-        const config = await context.config('config.yml')
         const title = context.payload.pull_request.title
         let whiteList
         if (config.updateDocsWhiteList) {

--- a/test/index.js
+++ b/test/index.js
@@ -64,7 +64,6 @@ describe('update-docs', () => {
         repo: 'testing-things',
         number: 21
       })
-      expect(github.repos.getContent).toNotHaveBeenCalled()
       expect(github.issues.createComment).toNotHaveBeenCalled()
     })
   })


### PR DESCRIPTION
Currently, this probot has hardcoded requirements that either a `README` or a `docs/` are modified for the notification to not trigger. Because projects have varying standards on what they name their documentation or where changes need to go on each pull request, this doesn't work in all situations.

This pull request adds a config option called `updateDocsTargetFiles` that allows someone to optionally configure different paths to check for docs updates on. It also modifies the tests to pass (because we now get repo content 100% of the time as opposed to only if docs aren't modified).