### PR TITLE
Fix wrong filepath in test code

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -56,7 +56,27 @@ describe('update-docs', () => {
       }))
     })
 
-    it('does not post a comment because the user DID update documentation', async () => {
+    it('does not post a comment because the user DID update documentation in /docs', async () => {
+      await robot.receive(payload)
+
+      expect(github.pullRequests.getFiles).toHaveBeenCalledWith({
+        owner: 'hiimbex',
+        repo: 'testing-things',
+        number: 21
+      })
+      expect(github.repos.getContent).toNotHaveBeenCalled()
+      expect(github.issues.createComment).toNotHaveBeenCalled()
+    })
+  })
+
+  describe('update docs fail', () => {
+    beforeEach(() => {
+      github.pullRequests.getFiles = expect.createSpy().andReturn(Promise.resolve({
+        data: [{filename: '/lib/main.js'}, {filename: '/README.md'}]
+      }))
+    })
+
+    it('does not post a comment because the user DID update README.md', async () => {
       await robot.receive(payload)
 
       expect(github.pullRequests.getFiles).toHaveBeenCalledWith({

--- a/test/index.js
+++ b/test/index.js
@@ -52,7 +52,7 @@ describe('update-docs', () => {
   describe('update docs fail', () => {
     beforeEach(() => {
       github.pullRequests.getFiles = expect.createSpy().andReturn(Promise.resolve({
-        data: [{filename: '/lib/main.js'}, {filename: '/docs/main.md'}]
+        data: [{filename: 'lib/main.js'}, {filename: 'docs/main.md'}]
       }))
     })
 
@@ -72,7 +72,7 @@ describe('update-docs', () => {
   describe('update docs fail', () => {
     beforeEach(() => {
       github.pullRequests.getFiles = expect.createSpy().andReturn(Promise.resolve({
-        data: [{filename: '/lib/main.js'}, {filename: '/README.md'}]
+        data: [{filename: 'lib/main.js'}, {filename: 'README.md'}]
       }))
     })
 


### PR DESCRIPTION
`test/index.js` contains two patterns of file path:

1. which starts with `/`
2. which does not start with `/`

I guess 1 is wrong (or current implementation cannot treat `README.md` as document), is it true?

Sorry to say but [official document of github api](https://octokit.github.io/node-github/#api-pullRequests-getFiles) does not provide example output, and I haven't confirmed that actual output starts with `/` or not.

I want to confirm this with you first, before I propose [another PR to treat `CHANGELOG.md` as document](https://github.com/behaviorbot/update-docs/compare/master...KengoTODA:consider-changelog-as-document).